### PR TITLE
0x15c0: add parsing and patching support

### DIFF
--- a/tcfp.py
+++ b/tcfp.py
@@ -49,6 +49,31 @@ pciIds = [
 slSigs = [
     # Listing all known patterns here, including tested NVM version.
     # NVM 33
+     {'pci-id': 0x15c0,
+     'sl': 0,
+     'sig': [
+        {'offset': 0x0,
+        'value': b'\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF'},
+        {'offset': 0x1800, 'value': b'\x18'}],
+     'patch': None,
+     },
+    {'pci-id': 0x15c0,
+     'sl': 1,
+     'sig': [
+        {'offset': 0x0,
+        'value': b'\x00\x40\x00\x00\x00\x00\x08\x00\x00\x00\x00\x00\x00\x00\x00\x00'},
+        {'offset': 0x800, 'value': b'\x19'}],
+     'patch': [
+        {'offset': 0x0,
+        'value': b'\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF'},
+        {'offset': 0x800, 'value': b'\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF'},
+        {'offset': 0xFFC, 'value': b'\xFF\xFF\xFF\xFF'},
+        {'offset': 0x1000,
+        'value': b'\x00\x40\x00\x00\x00\x00\x08\x00\x00\x00\x00\x00\x00\x00\x00\x00'},
+         {'offset': 0x1800, 'value': b'\x18\x00\x00\x00\x00\x00\x00\x00'},
+         {'offset': 0x1ffc, 'value': b'\x10\x40\x03\x00'},
+         {'offset': 0x20f4, 'value': b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'}],
+    },
     {'pci-id': 0x15da,
      'sl': 0,
      'sig': [{'offset': 0x800, 'value': b'\x18'}],


### PR DESCRIPTION
Add parsing and patching support for the following controller:

-  PCI ID : 0x15c0
-  PCI Device Name : JHL6240 Thunderbolt 3 Bridge (Low Power) [Alpine Ridge LP 2016]
-  NVM version: 4 (0x4)

This commit includes:

-  Signatures for SL0, SL1
-  Patching support for SL1 -> SL0

Tested on a ThinkPad T470
Fixes #5.